### PR TITLE
Update README, Config and ConfigSource

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,7 @@ Typically, the majority of applications need to be configured based on a running
 There are a number of Config supporting projects, such as:
 
 * Netflix Archaius (https://github.com/Netflix/archaius)
-* DeltaSpike Config (https://github.com/struberg/javaConfig/)
+* DeltaSpike Config (http://deltaspike.apache.org/documentation/configuration.html)
 * Apache Tamaya (http://tamaya.incubator.apache.org/)
 
 == Design

--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,8 @@
 //
-// Licensed to the Apache Software Foundation (ASF) under one or more
-// contributor license agreements.  See the NOTICE file distributed with
-// this work for additional information regarding copyright ownership.
-// The ASF licenses this file to You under the Apache License, Version 2.0
-// (the "License"); you may not use this file except in compliance with
-// the License.  You may obtain a copy of the License at
+// Copyright (c) 2016, 2017 IBM Corp. and others
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at
 //
 //   http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/src/main/java/io/microprofile/config/Config.java
+++ b/src/main/java/io/microprofile/config/Config.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2017 IBM Corp. and others
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.Optional;
  * 
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
+ * @author <a href=mailto:werner@catmedia.site">Werner Keil</a>
  *
  */
 public interface Config {	

--- a/src/main/java/io/microprofile/config/Config.java
+++ b/src/main/java/io/microprofile/config/Config.java
@@ -42,7 +42,6 @@ public interface Config {
 	 */
 	<T> Optional<T> getValue(String propertyName, Class<T> propertyType);
 	
-	
     /**
      * Get an Optional string associated with the given configuration propertyName.
      *
@@ -60,10 +59,8 @@ public interface Config {
 	 */
 	Iterable<String> getPropertyNames();	
 
-   
     /**
      * @return all currently registered {@link ConfigSource}s
      */
     Iterable<ConfigSource> getConfigSources();
-
 }

--- a/src/main/java/io/microprofile/config/spi/ConfigSource.java
+++ b/src/main/java/io/microprofile/config/spi/ConfigSource.java
@@ -76,11 +76,11 @@ public interface ConfigSource {
 	String getValue(String propertyName);
 
 	/**
-	 * The name of the config source might be used for logging or analysis of
+	 * The id of the config source might be used for logging or analysis of
 	 * configured values.
 	 *
-	 * @return the 'name' of the configuration source, e.g. 'property-file
+	 * @return the id of the configuration source, e.g. 'property-file
 	 *         mylocation/myproperty.properties'
 	 */
-	String getName();
+	String getId();
 }

--- a/src/main/java/io/microprofile/config/spi/ConfigSource.java
+++ b/src/main/java/io/microprofile/config/spi/ConfigSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBM Corp. and others
+ * Copyright (c) 2016, 2017 IBM Corp. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,62 +16,71 @@
  *******************************************************************************/
 package io.microprofile.config.spi;
 
-
 import io.microprofile.config.ConfigProvider.ConfigBuilder;
 
 import java.util.Map;
 
-
 /**
- * <p> Represent a config source, which provides properties. The config source includes: properties, xml, json files or datastore. <p>
+ * <p>
+ * Represent a config source, which provides properties. The config source
+ * includes: properties, xml, json files or datastore.
+ * <p>
  * The default config sources:
- * <ol> 
+ * <ol>
  * <li>System properties (ordinal=400)</li>
  * <li>Environment properties (ordinal=300)</li>
  * <li>/META-INF/config.properties (ordinal=100)</li>
  * <li>/META-INF/config.xml (ordinal=100)</li>
  * <li>/META-INF/config.json (ordinal=100)</li>
  * </ol>
- * The other custom config source can be added programmatically via {@link ConfigBuilder}. 
+ * The other custom config source can be added programmatically via
+ * {@link ConfigBuilder}.
+ * 
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
- *
+ * @author <a href=mailto:werner@catmedia.site">Werner Keil</a>
  */
 public interface ConfigSource {
 	/**
 	 * Return the properties in this config source
+	 * 
 	 * @return the map containing the properties in this config source
 	 */
 	Map<String, String> getProperties();
+
 	/**
-	 * Return the ordinal for this config source. The higher the more important. If a property is specified in multiple config sources, the value 
-	 * in the config source with the highest ordinal will be used.
-	 * The ordinal for the default config sources:
-	 *  <ol> 
+	 * Return the ordinal for this config source. The higher the more important.
+	 * If a property is specified in multiple config sources, the value in the
+	 * config source with the highest ordinal will be used. The ordinal for the
+	 * default config sources:
+	 * <ol>
 	 * <li>System properties (ordinal=400)</li>
 	 * <li>Environment properties (ordinal=300)</li>
 	 * <li>/META-INF/config.properties (ordinal=100)</li>
 	 * <li>/META-INF/config.xml (ordinal=100)</li>
 	 * <li>/META-INF/config.json (ordinal=100)</li>
 	 * </ol>
+	 * 
 	 * @return the ordinal value
 	 */
 	int getOrdinal();
+
 	/**
 	 * Return the value for the specified property in this config source.
-	 * @param propertyName the property name
-	 * @return the property value 
+	 * 
+	 * @param propertyName
+	 *            the property name
+	 * @return the property value
 	 */
 	String getValue(String propertyName);
-	
-	/**
-     * The name of the config might be used for logging or analysis of configured values.
-     *
-     * @return the 'name' of the configuration source, e.g. 'property-file mylocation/myproperty.properties'
-     */
-    String getConfigName();
-    
-	
 
+	/**
+	 * The name of the config source might be used for logging or analysis of
+	 * configured values.
+	 *
+	 * @return the 'name' of the configuration source, e.g. 'property-file
+	 *         mylocation/myproperty.properties'
+	 */
+	String getName();
 }


### PR DESCRIPTION
Fixed the link to DeltaSpike Config The old link was not DeltaSpike Config but something inspired by it.

The JavaDoc of `ConfigSource` states
```
  @return the 'name' of the configuration source, e.g. 'property-file
	 *         mylocation/myproperty.properties'
```
For the "name of the configuration source" isn't it better to simply call it `getName()`.
