### PR TITLE
Define escaping when expressions and array conversion are combined

### DIFF
--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -63,12 +63,25 @@ Converters can be added to the `ConfigBuilder` programmatically via `ConfigBuild
 where the type of the converters can be obtained via reflection. However, this is not possible for a lambda converter.
 In this case, use the method `ConfigBuilder#withConverter(Class<T> type, int priority, Converter<T> converter)`.
 
+[#array_converters]
 === Array Converters
 
 For the built-in converters and custom converters, the corresponding Array converters are provided by default.
-The delimiter for the config value is ",".
-The escape character is "\".
-e.g. With this config `myPets=dog,cat,dog\,cat`, the values as an array will be `{"dog", "cat", "dog,cat"}`.
+The delimiter for the config value is `,` and the escape character is `\`.
+In a plain value, a literal delimiter is escaped with a single backslash: `pets=dog,cat,dog\,cat`, the values as
+an array will be `{"dog", "cat", "dog,cat"}`.
+
+Property-expression resolution (see <<property-expressions>>) is applied _before_ the value is split. When a value also
+contains an expression it is processed by two stages, resolution then splitting, so a literal delimiter must be escaped
+for each stage, using a double backslash. For example:
+
+[source,properties]
+----
+pets=cat,dog,${mouse},sea\\,turtle
+----
+
+the resulting array is `{"cat", "dog", "mouse", "sea,turtle"}`. A single backslash here (`sea\,turtle`) would be
+consumed by expression resolution, leaving `sea` and `turtle` as separate elements.
 
 ==== Programmatic lookup
 

--- a/spec/src/main/asciidoc/property-expressions.asciidoc
+++ b/spec/src/main/asciidoc/property-expressions.asciidoc
@@ -67,20 +67,37 @@ including `getValue`, `getValues`, `getConfigValue`, `getValues`, `getOptionalVa
 and `getConfigProperties`. The methods `getValue` and `getProperties` in `ConfigSource`, may support property
 expressions as well, but it is not required by the specification.
 
+Expression resolution is applied to a value _before_ it is split into elements by an array or collection converter.
+Consequently, an expression that resolves to a value containing delimiters expands into multiple elements, and a
+literal delimiter that must be preserved is escaped as described in <<converters>>.
+
 Property expressions must also be applied to configuration properties injected via CDI. A default value
 defined via `org.eclipse.microprofile.config.inject.ConfigProperty#defaultValue` is not eligible to be expanded since
 multiple candidates may be available.
 
-If a configuration property value or default value requires the raw value without expansion, the expression may be
-escaped with a backslash ("\", double "\\" for property file-based sources). For instance:
+=== Escaping
+
+The backslash (`\`) is the escape character within a configuration value, and `$` has no special meaning on its own.
+To keep an expression from being resolved, escape it: `\${...}` resolves to the literal text `${...}`. A literal
+backslash is written `\\`.
 
 [source,properties]
 ----
-server.url=\\${server.host}
+server.url=\${server.host}
 server.host=localhost
 ----
 
 The value of `server.url` is `${server.host}`.
+
+Escaping composes across processing stages: a value is first resolved for expressions and, when read as a collection
+or array, the resolved value is then split into elements (see <<converters#array_converters>>). Each stage that
+interprets the value consumes one level of escaping, so a character that must survive more than one stage must be
+escaped once per stage.
+
+NOTE: A ConfigSource format may apply its own escaping when it is parsed. In a Java `.properties` file the backslash is
+itself the file-format escape character, so the value above is written `server.url=\\${server.host}` in the file; after
+the file is parsed the configuration value is `\${server.host}`. The escaping described here applies to the
+configuration _value_, after any source-specific unescaping.
 
 === Backwards Compatibility
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/PropertyExpressionsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/PropertyExpressionsTest.java
@@ -205,7 +205,7 @@ public class PropertyExpressionsTest extends Arquillian {
 
     @Test
     void arrayEscapes() {
-        Config config = buildConfig("list", "cat,dog,${mouse},sea\\,turtle", "mouse", "mouse");
+        Config config = buildConfig("list", "cat,dog,${mouse},sea\\\\,turtle", "mouse", "mouse");
 
         final List<String> list = config.getValues("list", String.class);
         assertEquals(list.size(), 4);


### PR DESCRIPTION
MicroProfile Config defines two features that both use the backslash `\` as their escape character and can appear in the same value: property expressions `${...}` and array/collection conversion `,` (comma-delimited), but the spec never states how they interact. There is no defined order between resolution and splitting, and no rule for how the two escapes compose. As a result, the behavior at the intersection is under-specified, and the TCK's arrayEscapes is the only case exercising the combination.

Adopt one governing principle: a value flows through interpreters in a defined order: expressions are resolved first, then the result is split into elements (if required). Each stage that interprets the value consumes one level of escaping. A character that must survive more than one stage is escaped once per stage. `$` alone has no special meaning; an expression is escaped with `\${...}`.

`\$` escapes an expression (one stage), while a literal delimiter in a value that also contains an expression is written `\\,`.

### What will this solve?

- Neither feature's escaping needs to know about the other's; the composition rule is stated once, globally.
- Apply stage 1, then stage 2, each with its own escapes; assigns every input exactly one meaning, removing any ambiguity over which stage owns a lone backslash.
- Same as when writing a regex inside a string literal
- Plain lists and expressions without literal delimiters are unaffected; only the rare value that mixes an expression with a literal delimiter needs the extra backslash.

### Changes

- `property-expressions.asciidoc`: new Escaping section; escape char, `\${...}`, `\\`, the per-stage composition rule, and a note separating config-value escaping from `.properties` file-format doubling; plus a paragraph stating resolution precedes array splitting.
- `spec/converters.asciidoc`: Array Converters now documents single-backslash for plain values and the double-backslash rule when an expression is present, with a worked example.
- `org.eclipse.microprofile.config.tck.PropertyExpressionsTest#arrayEscapes`: the delimiter is now escaped with a double backslash.