### PR TITLE
Ship an explicit module descriptor in microprofile-config-api

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -91,9 +91,35 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- The descriptor lives outside the javadoc source roots: keep the class path mode. -->
+                    <!--
+                        Keep javadoc in class path mode: a module-info.java at the root of a source path would switch
+                        it to module mode, so only the regular sources are documented.
+                    -->
                     <legacyMode>true</legacyMode>
+                    <sourcepath>${project.build.sourceDirectory}</sourcepath>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <!--
+                        Register the descriptor source root only once compilation is over, so that the
+                        sources jar ships module-info.java while the default compilation keeps ignoring it.
+                    -->
+                    <execution>
+                        <id>add-module-info-source</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/src/main/module-info</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -65,7 +65,7 @@
                     -->
                     <execution>
                         <id>compile-module-info</id>
-                        <phase>compile</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -72,6 +72,10 @@
                         <configuration>
                             <!-- module-info requires at least Java 9; the other classes stay on the project baseline. -->
                             <release>9</release>
+                            <!--
+                                Restricts this execution to the descriptor only (maven-compiler-plugin 3.x honours
+                                this parameter): src/main/java is not recompiled and keeps its Java 8 bytecode.
+                            -->
                             <compileSourceRoots>
                                 <compileSourceRoot>${project.basedir}/src/main/module-info</compileSourceRoot>
                             </compileSourceRoots>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -53,6 +53,44 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!--
+                        The module descriptor is compiled in a dedicated execution, patched onto the
+                        already compiled classes. This keeps the main compilation unchanged (class path)
+                        and avoids requiring the OSGi/bnd annotation jars referenced by package-info.java,
+                        which are compile-time only and ship no module descriptor.
+                    -->
+                    <execution>
+                        <id>compile-module-info</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <!-- module-info requires at least Java 9; the other classes stay on the project baseline. -->
+                            <release>9</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/module-info</compileSourceRoot>
+                            </compileSourceRoots>
+                            <compilerArgs>
+                                <arg>--patch-module</arg>
+                                <arg>org.eclipse.microprofile.config=${project.build.outputDirectory}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- The descriptor lives outside the javadoc source roots: keep the class path mode. -->
+                    <legacyMode>true</legacyMode>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -19,17 +19,10 @@
 
 /**
  * MicroProfile Config API.
- *
- * <p>
- * {@code @ConfigProperty} and {@code @ConfigProperties} are meta-annotated with
- * {@code jakarta.inject.Qualifier} / {@code jakarta.enterprise.util.Nonbinding} and
- * {@code ConfigProperties.Literal} extends {@code AnnotationLiteral}, so the Inject and CDI modules
- * are required transitively: consumers must read them for the API to be fully resolvable on the
- * module path.
  */
 module org.eclipse.microprofile.config {
-    requires transitive jakarta.cdi;
-    requires transitive jakarta.inject;
+    requires static transitive jakarta.cdi;
+    requires static transitive jakarta.inject;
 
     exports org.eclipse.microprofile.config;
     exports org.eclipse.microprofile.config.inject;

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -15,19 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Contributors:
- *   2011-12-28 - Mark Struberg & Gerhard Petracek
- *      Initially authored in Apache DeltaSpike as ConfigResolver fb0131106481f0b9a8fd
- *   2015-04-30 - Ron Smeral
- *      Typesafe Config authored in Apache DeltaSpike 25b2b8cc0c955a28743f
- *   2016-07-14 - Mark Struberg
- *      Extracted the Config part out of Apache DeltaSpike and proposed as Microprofile-Config
- *   2016-11-14 - Emily Jiang / IBM Corp
- *      Experiments with separate methods per type, JavaDoc, method renaming
- *   2018-04-04 - Mark Struberg, Manfred Huber, Alex Falb, Gerhard Petracek
- *      ConfigSnapshot added. Initially authored in Apache DeltaSpike fdd1e3dcd9a12ceed831dd
- *      Additional reviews and feedback by Tomas Langer.
  */
 
 /**

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *   2011-12-28 - Mark Struberg & Gerhard Petracek
+ *      Initially authored in Apache DeltaSpike as ConfigResolver fb0131106481f0b9a8fd
+ *   2015-04-30 - Ron Smeral
+ *      Typesafe Config authored in Apache DeltaSpike 25b2b8cc0c955a28743f
+ *   2016-07-14 - Mark Struberg
+ *      Extracted the Config part out of Apache DeltaSpike and proposed as Microprofile-Config
+ *   2016-11-14 - Emily Jiang / IBM Corp
+ *      Experiments with separate methods per type, JavaDoc, method renaming
+ *   2018-04-04 - Mark Struberg, Manfred Huber, Alex Falb, Gerhard Petracek
+ *      ConfigSnapshot added. Initially authored in Apache DeltaSpike fdd1e3dcd9a12ceed831dd
+ *      Additional reviews and feedback by Tomas Langer.
+ */
+
+/**
+ * MicroProfile Config API.
+ *
+ * <p>
+ * {@code @ConfigProperty} and {@code @ConfigProperties} are meta-annotated with
+ * {@code jakarta.inject.Qualifier} / {@code jakarta.enterprise.util.Nonbinding} and
+ * {@code ConfigProperties.Literal} extends {@code AnnotationLiteral}, so the Inject and CDI modules
+ * are required transitively: consumers must read them for the API to be fully resolvable on the
+ * module path.
+ */
+module org.eclipse.microprofile.config {
+    requires transitive jakarta.cdi;
+    requires transitive jakarta.inject;
+
+    exports org.eclipse.microprofile.config;
+    exports org.eclipse.microprofile.config.inject;
+    exports org.eclipse.microprofile.config.spi;
+
+    uses org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+}


### PR DESCRIPTION
Fixes #815

Adds an explicit `module-info.java` to `microprofile-config-api` so the MicroProfile Config API can be consumed as a proper Java module instead of an automatic one (context: [mailing-list thread](https://groups.google.com/g/microprofile/c/h2e3FicNw5k), same change proposed for every affected MicroProfile API).

The change is designed to be **mergeable in the next minor release without touching the Java 8 baseline**: the API classes are still compiled with `--release 8`, and the only Java 9 element is the `module-info.class` itself, compiled by a dedicated execution (the approach used by e.g. SLF4J 2.x). Moving to `microprofile-parent` 3.x / Java 11 is a separate decision for the project; if and when it happens, the special-casing below disappears and the wiring becomes identical to the Health and Metrics PRs.

### The descriptor

```java
module org.eclipse.microprofile.config {
    requires static transitive jakarta.cdi;
    requires static transitive jakarta.inject;

    exports org.eclipse.microprofile.config;
    exports org.eclipse.microprofile.config.inject;
    exports org.eclipse.microprofile.config.spi;

    uses org.eclipse.microprofile.config.spi.ConfigProviderResolver;
}
```

The module name follows the `org.eclipse.microprofile.<spec>` convention (reverse-DNS of the root package, as already used by the Config API's `Automatic-Module-Name` and by the OpenAPI API's existing descriptor). The Jakarta modules are only referenced by the `@ConfigProperty` and `@ConfigProperties` annotations (`@Qualifier` meta-annotation, `AnnotationLiteral` subclasses); the programmatic API (`Config`, `ConfigProvider`, the `spi` package) is pure Java. They are therefore declared `requires static transitive`:

- `static`: optional at resolution time, so the module resolves on a module path without a CDI container. Whenever the annotations are actually used at run time it is through a CDI container, whose own module `requires` the Jakarta modules and therefore resolves them.
- `transitive`: when they are resolved, a module using `@ConfigProperty` reads `jakarta.cdi` and `jakarta.inject` implicitly, which is needed for the meta-annotations and the `AnnotationLiteral` supertypes to be resolvable from that module.

The same trade-off is applied to the other MicroProfile APIs whose Jakarta dependency is annotation-only (see the discussion on microprofile/microprofile-health#344, microprofile/microprofile-metrics#805 and microprofile/microprofile-fault-tolerance#660). The module Javadoc is deliberately kept to a one-liner; this rationale lives here instead.

### Build changes (`api/pom.xml`)

- The descriptor lives in `src/main/module-info/` and is compiled by a dedicated `maven-compiler-plugin` execution patched onto the already compiled classes (`--patch-module`). The main compilation is left untouched on the class path, and the descriptor does not have to `requires` the OSGi/bnd annotation jars used by `package-info.java`, which are compile-time only and ship no module descriptor of their own.
- The descriptor source root is registered with `build-helper-maven-plugin` at `prepare-package` (after compilation) so that the attached `*-sources.jar` ships `module-info.java` alongside the other sources.
- `maven-javadoc-plugin` is kept in class path mode (`legacyMode`) with an explicit `sourcepath` limited to `src/main/java`: javadoc would otherwise switch to module mode as soon as it finds a `module-info.java` at the root of a source path.
- The project baseline is Java 8 (`microprofile-parent` 2.x), so the dedicated execution uses `--release 9` — the only Java 9 exception in the build, so that this can land in the next minor release without waiting for a Java baseline bump. Should the project move to `microprofile-parent` 3.x (Java 11), this special case simply goes away. The resulting `module-info.class` (class file version 53) sits at the jar root next to Java 8 classes — the same layout used by e.g. SLF4J 2.x; a Java 8 runtime never loads `module-info` and OSGi/bnd ignore it. Packaging it as `META-INF/versions/9/` (multi-release) is possible too if the project prefers.

### Verification

- `mvn install -DskipTests` on the whole reactor passes.
- `jar --describe-module` on the built jar shows the descriptor above; OSGi headers (`Bundle-SymbolicName`, `Export-Package`, `Import-Package`) generated by bnd are unchanged.
- `java --module-path <api jar + compile deps> --describe-module org.eclipse.microprofile.config` resolves the module graph successfully (with the api jar alone on the module path it resolves as well, the Jakarta modules being optional).
- The `*-sources.jar` contains `module-info.java`; the `*-javadoc.jar` is unchanged.
